### PR TITLE
Fix IPv6 in allowed hosts 

### DIFF
--- a/src/wissenslandkarte/settings.py
+++ b/src/wissenslandkarte/settings.py
@@ -49,7 +49,7 @@ SECRET_KEY = load_or_create_secret_key()
 ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
-    '::1',
+    '[::1]',
     'python',
     # 'wissenslandkarte.betreiberverein.de',
 ]


### PR DESCRIPTION
'::1' does not recognize the URL http://[::1] as a valid destination; ALLOWED_HOSTS requires '[::1]' instead.